### PR TITLE
feat: multi-run benchmark with cross-platform RSS/CPU sampling

### DIFF
--- a/artemis_scripts/benchmark.py
+++ b/artemis_scripts/benchmark.py
@@ -1,0 +1,21 @@
+import json
+import os
+
+import psutil
+
+
+def main():
+    process = psutil.Process(os.getpid())
+    with open("artemis_raw.json") as f:
+        data = json.load(f)
+    stats = data["benchmarks"][0]["stats"]
+    print("throughput,memory_peak,cpu_usage")
+    print(
+        f'{stats["ops"]},'
+        f"{process.memory_info().rss / (1024 * 1024)},"
+        f"{psutil.cpu_percent(interval=1)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/artemis_scripts/benchmark.py
+++ b/artemis_scripts/benchmark.py
@@ -1,20 +1,76 @@
+import argparse
 import json
-import os
+import subprocess
+import sys
+import time
+from pathlib import Path
 
 import psutil
 
 
+def _total_rss(procs):
+    total = 0
+    for p in procs:
+        try:
+            total += p.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return total
+
+
+def run_once(raw_json_path: Path) -> dict:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "tests/",
+        "--benchmark-only",
+        f"--benchmark-json={raw_json_path}",
+    ]
+    psutil.cpu_percent(interval=None)
+    proc = subprocess.Popen(cmd)
+    parent = psutil.Process(proc.pid)
+
+    peak_rss = 0
+    cpu_samples = []
+    while proc.poll() is None:
+        try:
+            procs = [parent] + parent.children(recursive=True)
+        except psutil.NoSuchProcess:
+            procs = []
+        peak_rss = max(peak_rss, _total_rss(procs))
+        cpu_samples.append(psutil.cpu_percent(interval=None))
+        time.sleep(0.05)
+    proc.wait()
+
+    with raw_json_path.open() as f:
+        stats = json.load(f)["benchmarks"][0]["stats"]
+
+    return {
+        "throughput": stats["ops"],
+        "memory_peak": peak_rss / (1024 * 1024),
+        "cpu_usage": sum(cpu_samples) / len(cpu_samples) if cpu_samples else 0.0,
+    }
+
+
 def main():
-    process = psutil.Process(os.getpid())
-    with open("artemis_raw.json") as f:
-        data = json.load(f)
-    stats = data["benchmarks"][0]["stats"]
-    print("throughput,memory_peak,cpu_usage")
-    print(
-        f'{stats["ops"]},'
-        f"{process.memory_info().rss / (1024 * 1024)},"
-        f"{psutil.cpu_percent(interval=1)}"
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--output", type=Path, default=Path("artemis_results.csv"))
+    parser.add_argument("--raw-json", type=Path, default=Path("artemis_raw.json"))
+    args = parser.parse_args()
+
+    rows = [run_once(args.raw_json) for _ in range(args.runs)]
+
+    with args.output.open("w") as f:
+        f.write("throughput,memory_peak,cpu_usage\n")
+        for r in rows:
+            f.write(f'{r["throughput"]},{r["memory_peak"]},{r["cpu_usage"]}\n')
+
+    try:
+        args.raw_json.unlink()
+    except FileNotFoundError:
+        pass
 
 
 if __name__ == "__main__":

--- a/artemis_scripts/benchmark.sh
+++ b/artemis_scripts/benchmark.sh
@@ -1,10 +1,10 @@
-#!/bin/bash     
+#!/usr/bin/env bash
 
 # Import variables
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$DIR/variables.sh"
 
-# Populate BENCHMARK with the benchmark command
-BENCHMARK="poetry run pytest --benchmark-only tests/"
-echo "Running benchmark command: $BENCHMARK"
-eval $BENCHMARK
+# Run benchmark, emit CSV, clean up raw JSON
+echo "Running benchmark"
+python -m poetry run pytest tests/ --benchmark-only --benchmark-json=artemis_raw.json && python -m poetry run python "$DIR/benchmark.py" > artemis_results.csv
+rm -f artemis_raw.json

--- a/artemis_scripts/benchmark.sh
+++ b/artemis_scripts/benchmark.sh
@@ -4,7 +4,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$DIR/variables.sh"
 
-# Run benchmark, emit CSV, clean up raw JSON
+# Run benchmark via Python orchestrator (cross-platform RSS/CPU sampling).
+# Forwards all args to benchmark.py (e.g. --runs N, --output PATH).
 echo "Running benchmark"
-python -m poetry run pytest tests/ --benchmark-only --benchmark-json=artemis_raw.json && python -m poetry run python "$DIR/benchmark.py" > artemis_results.csv
-rm -f artemis_raw.json
+python -m poetry run python "$DIR/benchmark.py" "$@"

--- a/artemis_scripts/build.sh
+++ b/artemis_scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash     
+#!/usr/bin/env bash
 
 # Import variables
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/artemis_scripts/clean.sh
+++ b/artemis_scripts/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash     
+#!/usr/bin/env bash
 
 # Import variables
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/artemis_scripts/test.sh
+++ b/artemis_scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash     
+#!/usr/bin/env bash
 
 # Import variables
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/artemis_scripts/variables.sh
+++ b/artemis_scripts/variables.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BEAR_EXE=bear

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,6 +73,41 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc"},
+    {file = "psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988"},
+    {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
+    {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 description = "Get CPU info with pure Python"
@@ -202,4 +237,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "7c1a79f9b9eab16c53386c77b9fa143ad54c7485721dbb7b3cee5cb7d724912b"
+content-hash = "50f946e0b58d18833980af24e7b6db5c38202dafb302386b8cd2457db0ed1ab0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.8"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
 pytest-benchmark = "^4.0.0"
+psutil = "^7.2.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- Add `psutil` as a dev dependency and emit benchmark results to `artemis_results.csv` (throughput, peak memory MB, CPU %).
- Rewrite `artemis_scripts/benchmark.py` as an orchestrator: spawns pytest as a subprocess and polls RSS of pytest + descendants via `psutil` to capture true peak memory; samples system CPU while pytest is running (was sampled after exit).
- Support multiple runs: `--runs N` writes N rows. `benchmark.sh` forwards all CLI args (`--runs`, `--output`, `--raw-json`) to `benchmark.py`.
- Sweep `artemis_scripts/*.sh` to `#!/usr/bin/env bash` for cross-platform shebang.

## Why
Previous implementation measured the inline helper script's own RSS, not pytest's — values were meaningless. New approach polls pytest's process tree directly via `psutil`, which abstracts Win/Linux/macOS process introspection.

## Test plan
- [x] `./artemis_scripts/benchmark.sh --runs 2` produces 2 CSV rows with realistic memory_peak (~400 MB) vs prior stub values (~89 MB).
- [ ] Verify on macOS.
- [ ] Verify on Windows (via Git Bash or direct `python artemis_scripts/benchmark.py --runs N`).