### PR TITLE
feat: per-test throughput and latency p50/p99 columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+artemis_results.csv
+artemis_raw.json

--- a/artemis_scripts/benchmark.py
+++ b/artemis_scripts/benchmark.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import psutil
 
 
+TEST_PREFIX = "test_benchmark_"
+
+
 def _total_rss(procs):
     total = 0
     for p in procs:
@@ -16,6 +19,17 @@ def _total_rss(procs):
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
     return total
+
+
+def _percentile(sorted_data, pct):
+    if not sorted_data:
+        return 0.0
+    idx = min(int(len(sorted_data) * pct), len(sorted_data) - 1)
+    return sorted_data[idx]
+
+
+def _short_name(full_name: str) -> str:
+    return full_name[len(TEST_PREFIX):] if full_name.startswith(TEST_PREFIX) else full_name
 
 
 def run_once(raw_json_path: Path) -> dict:
@@ -44,13 +58,20 @@ def run_once(raw_json_path: Path) -> dict:
     proc.wait()
 
     with raw_json_path.open() as f:
-        stats = json.load(f)["benchmarks"][0]["stats"]
+        benchmarks = json.load(f)["benchmarks"]
 
-    return {
-        "throughput": stats["ops"],
+    row = {
         "memory_peak": peak_rss / (1024 * 1024),
         "cpu_usage": sum(cpu_samples) / len(cpu_samples) if cpu_samples else 0.0,
     }
+    for b in sorted(benchmarks, key=lambda x: x["name"]):
+        name = _short_name(b["name"])
+        stats = b["stats"]
+        data_sorted = sorted(stats["data"])
+        row[f"{name}_throughput"] = stats["ops"]
+        row[f"{name}_latency_p50"] = stats["median"] * 1_000_000
+        row[f"{name}_latency_p99"] = _percentile(data_sorted, 0.99) * 1_000_000
+    return row
 
 
 def main():
@@ -61,11 +82,12 @@ def main():
     args = parser.parse_args()
 
     rows = [run_once(args.raw_json) for _ in range(args.runs)]
+    columns = list(rows[0].keys())
 
     with args.output.open("w") as f:
-        f.write("throughput,memory_peak,cpu_usage\n")
+        f.write(",".join(columns) + "\n")
         for r in rows:
-            f.write(f'{r["throughput"]},{r["memory_peak"]},{r["cpu_usage"]}\n')
+            f.write(",".join(f"{r[c]}" for c in columns) + "\n")
 
     try:
         args.raw_json.unlink()


### PR DESCRIPTION
## Summary
- `benchmark.py` now emits one column per `(test × metric)` for every pytest-benchmark test, matching the layout used by `sample-project-java`.
- Per test: `<name>_throughput` (ops/sec), `<name>_latency_p50` (μs, from `stats.median`), `<name>_latency_p99` (μs, computed from raw per-round timings in `stats.data`).
- Test names are sorted alphabetically for stable column order across runs; `test_benchmark_` prefix is stripped.
- Global per-run columns (`memory_peak`, `cpu_usage`) are preserved as the leading columns.

## Why
Java benchmark exports one row per execution with per-operation columns (`sumRange_throughput`, `sumRange_latency_p50`, `sumRange_latency_p99`, …). Python now mirrors this schema so downstream tooling can consume both sample projects uniformly.

## Test plan
- [x] `./artemis_scripts/benchmark.sh --runs 2` produces 2 rows × 56 columns (`memory_peak`, `cpu_usage`, plus 18 tests × 3 metrics).
- [x] Latency values are in microseconds (e.g. ~0.57 μs for `count_duplicates_latency_p50`).
- [x] Column order is stable across runs (alphabetical by test name).