### PR TITLE
perf: use built-in sorted() in DsList.sort_list

### DIFF
--- a/src/llm_benchmark/datastructures/dslist.py
+++ b/src/llm_benchmark/datastructures/dslist.py
@@ -45,13 +45,7 @@ class DsList:
         Returns:
             List[int]: Sorted list of integers
         """
-        ret = v.copy()
-        for i in range(len(ret)):
-            for j in range(i + 1, len(ret)):
-                if ret[i] > ret[j]:
-                    ret[i], ret[j] = ret[j], ret[i]
-
-        return ret
+        return sorted(v)
 
     @staticmethod
     def reverse_list(v: List[int]) -> List[int]:


### PR DESCRIPTION
## Summary
Replace the hand-rolled O(n²) bubble sort in `DsList.sort_list` with Python's built-in `sorted()`, improving performance and readability.

## Changes
- Replace nested-loop bubble sort with `sorted(v)` in `src/llm_benchmark/datastructures/dslist.py`
- Remove 6 lines of manual swap logic

## Validation
Validation commands configured for this project (run to verify the change is safe):
- **Compilation**: `uv pip install poetry && python -m poetry install`
- **Unit tests**: `python -m poetry run pytest --benchmark-skip tests/`
- **Benchmark**: `python -m poetry run pytest --benchmark-only tests/`

## Notes
`sorted()` returns a new list, preserving the original non-mutating behaviour of the previous implementation. Both produce identical ascending-order output for `List[int]`.

---

changeset_id: ec82b078-0eba-4148-bb3b-c831e6a77c1d

### Trigger Artemis Fix Agent to iterate on comments left on your PR

1. **Wait until your reviewers are done** leaving comments on the PR.
2. **Tag `@artemis-fix-agent` in a new comment** — this will be your trigger comment. Optionally, add further instructions you want Artemis to act on.

**Example trigger comment:**
```
@artemis-fix-agent address all the review feedback above.
```

Artemis will pick up **all existing PR comments** automatically. Note that each time you tag `@artemis-fix-agent`, a separate, parallel fix attempt will be kicked off, so only tag Artemis once you're ready to start.